### PR TITLE
release 워크플로우 파일에 permissions 설정 추가

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,5 +1,9 @@
 name: Release (release:next - Dev Merge)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request:
     types:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,9 @@
 name: Release (release:prod - Main Merge)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
# 🚀 release 워크플로우 파일에 permissions 설정 추가

## 📚 개요

#1 에서 릴리즈 PR 생성에 실패하여 원인을 찾아 수정한 PR입니다. **`release-next.yml`에 permissions 설정이 누락**되어 github actions 실행 시 changesets가 버전 업데이트 PR(릴리즈 PR)을 생성하지 못했습니다. 그 결과 릴리즈 PR을 만들지 못하고, 기능 PR이 dev 브랜치에 머지된 상태로 워크플로우가 종료되었습니다. 릴리즈 과정을 성공적으로 마치기 위해 **릴리즈 PR을 생성**해야 합니다.

<br />

## 💡 현재 상황

- #1 이 정상 머지되어 dev 브랜치에 `.changeset/*.md` 파일이 반영되어 있음
- 위 결과 릴리즈 PR이 생성되지는 않음
- 버전이 업데이트되거나 태그가 추가되지도 않음
  - github actions가 permissions가 필요한 상황까지 작업을 진행하였다는 것은 그 전에 이미 버전 업데이트와 태그 추가 작업을 실행했다는 것이지만, 최종적으로 PR 생성에 실패하였기에 실제로 반영되지는 않음

<br />

## ✅ 체크해야 할 사항

- `.changeset/*.md` 파일을 만든 PR의 본문 -> `CHANGELOG.md` -> 릴리즈 노트 순으로 영향을 끼침
- **#1 에 전반적인 설명을 모두 작성해두었기 때문에 새롭게 만든 본 PR의 본문이 #1 의 본문을 무시하고 `CHANGELOG.md`에 반영되도록 해서는 안됨**
- 현재 dev 브랜치에 #1 에서 만들었던 `.changeset/*.md`가 머지되어 있으므로 이를 그대로 유지하기 위해 본 PR에는 `.changeset/*.md`를 추가하지 않도록 함 (`pnpm changeset` 실행 X)

<br />

## 📌 변경 사항

- `release-next.yml`과 `release-prod.yml`에 permissions 설정 추가
  ```yaml
  permissions:
    contents: write
    pull-requests: write
  ```

<br />

## ⚠️ 유의 사항

- 본 PR이 생성, 업데이트될 때마다 `ci-next.yml` 파일이 실행됩니다.
- 그러나, CHANGELOG.md에 #1 의 본문 내용을 반영하기 위해 의도적으로 본 PR에서는 `.changeset/*.md` 파일을 누락시켰기에 CI가 통과하지 못합니다.
- 이는 **의도된 실패**이므로 CI가 통과하지 못하더라도 그대로 머지해야 합니다. (현재는 아직 브랜치 룰을 세팅하기 전이므로 CI가 실패하더라도 머지 가능)