### PR TITLE
release 워크플로우 파일 수정 (github actions 에러 대응)

### DIFF
--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -21,8 +21,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 2. PR 라벨 확인
+      # 2. 릴리즈 PR 여부 확인
+      - name: Check if release PR
+        id: check-release-pr
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" == "Version Packages"* ]]; then
+            echo "is_release_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      # 3. PR 라벨 확인 (릴리즈 PR이 아닐 때만)
       - name: Check PR labels
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # PR 라벨 목록 가져오기
           LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
@@ -50,8 +61,9 @@ jobs:
           # 유효한 라벨 출력
           echo "RELEASE_LABEL=${MATCHED_LABELS[0]}" >> $GITHUB_ENV
 
-      # 3. changeset 파일과 PR 라벨의 bump type 비교
+      # 4. changeset 파일과 PR 라벨의 bump type 비교 (릴리즈 PR이 아닐 때만)
       - name: Check changeset files
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # changeset 파일 확인
           if ! ls .changeset/*.md 1> /dev/null 2>&1; then
@@ -71,28 +83,28 @@ jobs:
             exit 1
           fi
 
-      # 4. pnpm 설치
+      # 5. pnpm 설치
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 9
           run_install: false
 
-      # 5. Node.js 설정
+      # 6. Node.js 설정
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
 
-      # 5-1. pnpm 캐시 경로 출력
+      # 6-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      # 5-2. pnpm 캐시 설정
+      # 6-2. pnpm 캐시 설정
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
@@ -101,22 +113,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      # 6. 의존성 설치
+      # 7. 의존성 설치
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 7. Lint 검사
+      # 8. Lint 검사
       - name: Run ESLint
         run: pnpm lint
 
-      # 8. Format 검사
+      # 9. Format 검사
       - name: Check formatting
         run: pnpm format:check
 
-      # 9. 테스트 실행
+      # 10. 테스트 실행
       - name: Run tests
         run: pnpm test
 
-      # 10. 라이브러리 빌드 테스트
+      # 11. 라이브러리 빌드 테스트
       - name: Build floaty-core
         run: time pnpm floaty:build:once

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -21,8 +21,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 2. PR 라벨 확인
+      # 2. 릴리즈 PR 여부 확인
+      - name: Check if release PR
+        id: check-release-pr
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" == "Version Packages"* ]]; then
+            echo "is_release_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      # 3. PR 라벨 확인 (릴리즈 PR이 아닐 때만)
       - name: Check PR labels
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # PR 라벨 목록 가져오기
           LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
@@ -50,8 +61,9 @@ jobs:
           # 유효한 라벨 출력
           echo "RELEASE_LABEL=${MATCHED_LABELS[0]}" >> $GITHUB_ENV
 
-      # 3. changeset 파일과 PR 라벨의 bump type 비교
+      # 4. changeset 파일과 PR 라벨의 bump type 비교 (릴리즈 PR이 아닐 때만)
       - name: Check changeset files
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # changeset 파일 확인
           if ! ls .changeset/*.md 1> /dev/null 2>&1; then
@@ -60,7 +72,7 @@ jobs:
           fi
 
           # changeset의 bump type 추출
-          BUMP_TYPE=$(cat .changeset/*.md | grep -o '"bump": "[^"]*"' | cut -d'"' -f4)
+          BUMP_TYPE=$(cat .changeset/*.md | grep -o '": [a-z]*' | sed 's/": //')
 
           # 라벨에서 bump type 추출
           LABEL_BUMP_TYPE=$(echo "$RELEASE_LABEL" | cut -d':' -f3)
@@ -71,28 +83,28 @@ jobs:
             exit 1
           fi
 
-      # 4. pnpm 설치
+      # 5. pnpm 설치
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 9
           run_install: false
 
-      # 5. Node.js 설정
+      # 6. Node.js 설정
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
 
-      # 5-1. pnpm 캐시 경로 출력
+      # 6-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      # 5-2. pnpm 캐시 설정
+      # 6-2. pnpm 캐시 설정
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
@@ -101,30 +113,30 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      # 6. 의존성 설치
+      # 7. 의존성 설치
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
-      # 7. Lint 검사
+      # 8. Lint 검사
       - name: Run ESLint
         run: pnpm lint
 
-      # 8. Format 검사
+      # 9. Format 검사
       - name: Check formatting
         run: pnpm format:check
 
-      # 9. 테스트 실행
+      # 10. 테스트 실행
       - name: Run tests
         run: pnpm test
 
-      # 10. 라이브러리 빌드 테스트
+      # 11. 라이브러리 빌드 테스트
       - name: Build floaty-core
         run: time pnpm floaty:build:once
 
-      # 11. jsdocs 빌드 테스트
+      # 12. jsdocs 빌드 테스트
       - name: Build jsdocs
         run: pnpm floaty:docs:build
 
-      # 12. storybook 빌드 테스트
+      # 13. storybook 빌드 테스트
       - name: Build storybook
         run: pnpm vanilla:sb:build

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,5 +1,9 @@
 name: Release (release:next - Dev Merge)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request:
     types:
@@ -55,12 +59,10 @@ jobs:
 
       # 5. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
       - name: Create release pull request or publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          publish: |
-            if pnpm ci:publish:next; then
-              echo "published=true" > .published
-            fi
+          publish: pnpm ci:publish:next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -68,8 +70,10 @@ jobs:
       # 5-1. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
+        env:
+          PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
-          if [ -f .published ]; then
+          if [ "$PUBLISHED" = "true" ]; then
             echo "PUBLISHED=true" >> $GITHUB_OUTPUT
           else
             echo "PUBLISHED=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,9 @@
 name: Release (release:prod - Main Merge)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   pull_request:
     types:
@@ -55,12 +59,10 @@ jobs:
 
       # 5. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
       - name: Create release pull request or publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          publish: |
-            if pnpm ci:publish; then
-              echo "published=true" > .published
-            fi
+          publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -68,8 +70,10 @@ jobs:
       # 5-1. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
+        env:
+          PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
-          if [ -f .published ]; then
+          if [ "$PUBLISHED" = "true" ]; then
             echo "PUBLISHED=true" >> $GITHUB_OUTPUT
           else
             echo "PUBLISHED=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# release 워크플로우 파일 수정 (github actions 에러 대응)

## 📜 히스토리

- #1 머지할 때 github actions 에러로 dev 브랜치로 머지만 되고 릴리즈 PR 생성 안됨
- #4 에서 위 에러 수정하고 동시에 `.changeset/*.md` 파일을 제거하여 dev 브랜치로 머지함
- #4 를 머지하면서 원래 의도와는 달리 github actions 실행의 대상이 되는 dev 브랜치에 `.changeset/*.md`가 존재하지 않게 되어 `changesets/action@v1`가 릴리즈 PR이 아니라 publish 시도하게 됨
- github actions에서 에러가 발생하여 publish 실패함

<br />

## 📚 개요

#1 에서 발생한 github actions 에러를 #4 에서 수정 및 머지하면서 dev 브랜치에 `.changeset/*.md` 파일이 제거되어 github actions가 릴리즈 PR을 생성하지 않고 publish를 시도하였습니다. 해당 PR은 머지되면서 publish가 아니라 릴리즈 PR을 생성하고, 이때 #1 의 본문 내용을 `CHANGELOG.md`에 반영하도록 하기 위해 작업되었습니다.

<br />

## ✅ 체크해야 할 사항들

- 다행히 스크립트 에러가 있어 publish는 실패하였으나 그대로 에러 수정을 포함한 새로운 PR을 올리면 여전히 dev 브랜치에는 `.changeset/*.md`가 존재하지 않아 같은 과정이 반복됩니다.
- 그렇다고 새로운 PR 브랜치에서 `pnpm changeset`을 실행하여 `.changeset/*.md` 파일을 새로 만든다면, #1 의 본문 내용이 `CHANGELOG.md`에 반영되지 않습니다.
  - `@changesets/changelog-github`는 `changeset/*.md`이 만들어진 시점의 PR의 본문 내용을 `CHANGELOG.md`에 반영하기 때문

<br />

## 📌 변경 사항

### 1) `.changeset/*.md` 원본 파일 복원

- `.changeset/*.md` 파일은 단순히 이전 파일을 복붙한다고 완전한 의미의 복원이 되는 것이 아님. 이전 파일을 복붙하더라도 해당 작업을 포함하는 PR이 머지되는 시점에 해당 PR을 참고하여 CHANGELOG.md를 구성하기 때문에 복붙은 의미 없음.
- #4 가 머지된 시점에 dev 브랜치에는 `.changeset/*.md` 파일이 없으므로 원본 `.changeset/*.md`를 복원하기 위해 로컬에서 #1 머지 시점으로 reset 실행
- 위 문제를 해결하고 더불어 dev 브랜치를 정리하기 위해 강제 푸시 진행

```bash
git checkout dev
git reset --hard {#1 머지 커밋}
git push --force
```

### 2) release 워크플로우 파일 수정 (github actions 에러 대응)

- `changesets`이 릴리즈 PR을 생성할 수 있도록 permissions 설정 추가
- `changesets/action@v1` 실행 시 `with.publish`에서 쉘 스크립트 제거
  - if 문 삭제하고, 다음 스텝에서 `outputs.published` 값을 env로 받아 사용하도록 수정

### 3) ci 워크플로우 파일 수정

- 릴리즈 PR 여부에 따른 분기 처리 추가
  - 릴리즈 PR이 아닐 때만, PR 라벨을 확인하고 PR 라벨과 `.changeset/*.md`의 bump type을 비교하도록 함
  - 릴리즈 PR일 때는, `.changeset/*.md` 파일이 없기 때문에 위 과정에서 에러가 발생하기 때문

<br />

## ✨ 본 PR 생성, 머지 이후의 예상 플로우

- PR 생성 -> CI 통과
- PR 머지 -> 머지된 후의 dev 브랜치에 `.changeset/*.md` 파일이 존재하므로 `changesets/action@v1`이 publish가 아니라 릴리즈 PR 생성
- 릴리즈 PR 생성 -> CI 통과
- 릴리즈 PR 머지 -> `changesets/action@v1`이 npm publish 진행