### PR TITLE
워크플로우 파일에서 PAT 사용 (github actions 에러 대응)

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           publish: pnpm ci:publish:next
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # 5-1. npm 레지스트리 배포 여부 확인
@@ -102,7 +102,7 @@ jobs:
           RELEASE_TAG: v${{ steps.changelog.outputs.VERSION }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.NOTES }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const tag = process.env.RELEASE_TAG;

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           publish: pnpm ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # 5-1. npm 레지스트리 배포 여부 확인
@@ -102,7 +102,7 @@ jobs:
           RELEASE_TAG: v${{ steps.changelog.outputs.VERSION }}
           RELEASE_NOTES: ${{ steps.changelog.outputs.NOTES }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const tag = process.env.RELEASE_TAG;
@@ -129,6 +129,6 @@ jobs:
       - name: Deploy Storybook to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           publish_dir: ./website
           publish_branch: gh-pages

--- a/docs/release-next.md
+++ b/docs/release-next.md
@@ -182,7 +182,7 @@ on:
           echo "published=true" > .published
         fi
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   ```
 </aside>

--- a/docs/release-prod.md
+++ b/docs/release-prod.md
@@ -200,7 +200,7 @@ on:
           echo "published=true" > .published
         fi
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   ```
 </aside>


### PR DESCRIPTION
# 워크플로우 파일에서 PAT 사용 (github actions 에러 대응)

## 📜 히스토리

- 관련 PR #5 참고
- 최초 프리릴리즈 실험 중에 github actions 에러가 발생하여 해결 중에 있습니다

<br />

## 📚 개요

github actions가 실행되는 중에 `changesets`가 릴리즈 PR을 생성하기 위해서는 권한이 필요합니다. #5 에서 `release-next.yml`과 `release-prod.yml`에 permissions 설정을 추가하였으나, `changesets`는 여전히 릴리즈 PR 생성 권한을 가지고 있지 않아 github actions 실행 중 에러가 발생했습니다. 본 PR은 이를 해결하기 위한 수정 작업을 포함합니다.

<br />

## 📌 변경 사항

### 1) github에서 PAT 생성

이는 다음과 같은 필수 권한을 포함합니다.

  - Repository contents: Read and Write
  - Pull requests: Read and Write

### 2) `secrets.GITHUB_TOKEN` -> `secrets.PERSONAL_GITHUB_TOKEN` 변경

`release-next.yml`과 `release-prod.yml`에서 기존에 사용하고 있던 `secrets.GITHUB_TOKEN`을 `secrets.PERSONAL_GITHUB_TOKEN`으로 변경하였습니다.