### PR TITLE
워크플로우 파일들 수정 (github actions 에러 대비)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,6 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,5 @@
   "linked": [],
   "access": "public",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["vanilla"]
 }

--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -33,13 +33,14 @@ jobs:
 
       # 3. PR 라벨 확인 (릴리즈 PR이 아닐 때만)
       - name: Check PR labels
+        id: check-pr-labels
         if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # PR 라벨 목록 가져오기
           LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
 
           # 유효한 라벨 목록
-          VALID_LABELS=("release:next:patch" "release:next:minor" "release:next:major")
+          VALID_LABELS=("release:next:patch" "release:next:minor" "release:next:major" "no-release")
 
           # 유효한 라벨 필터링
           MATCHED_LABELS=()
@@ -54,7 +55,7 @@ jobs:
           MATCHED_COUNT=${#MATCHED_LABELS[@]}
 
           if [ "$MATCHED_COUNT" -ne 1 ]; then
-            echo "::error::Exactly one valid release label must be present. Found $MATCHED_COUNT. Expected one of: ${VALID_LABELS[*]}"
+            echo "::error::Exactly one valid label must be present. Found $MATCHED_COUNT. Expected one of: ${VALID_LABELS[*]}"
             exit 1
           fi
 
@@ -63,7 +64,7 @@ jobs:
 
       # 4. changeset 파일과 PR 라벨의 bump type 비교 (릴리즈 PR이 아닐 때만)
       - name: Check changeset files
-        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' && steps.check-pr-labels.outputs.RELEASE_LABEL != 'no-release' }}
         run: |
           # changeset 파일 확인
           if ! ls .changeset/*.md 1> /dev/null 2>&1; then

--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -96,6 +96,8 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@seo-ny"
 
       # 6-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory

--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -31,7 +31,7 @@ jobs:
             echo "is_release_pr=false" >> $GITHUB_OUTPUT
           fi
 
-      # 3. PR 라벨 확인 (릴리즈 PR이 아닐 때만)
+      # 3. PR 라벨 확인
       - name: Check PR labels
         id: check-pr-labels
         if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
@@ -62,7 +62,7 @@ jobs:
           # 유효한 라벨 출력
           echo "RELEASE_LABEL=${MATCHED_LABELS[0]}" >> $GITHUB_ENV
 
-      # 4. changeset 파일과 PR 라벨의 bump type 비교 (릴리즈 PR이 아닐 때만)
+      # 4. changeset 파일과 PR 라벨의 bump type 비교
       - name: Check changeset files
         if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' && steps.check-pr-labels.outputs.RELEASE_LABEL != 'no-release' }}
         run: |

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -96,6 +96,8 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@seo-ny"
 
       # 6-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -15,6 +15,8 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.check-published.outputs.published }}
 
     steps:
       # 1. 레포지토리 체크아웃
@@ -72,21 +74,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # 6-1. npm 레지스트리 배포 여부 확인
+      # 7. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
-        env:
-          PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
-          if [ "$PUBLISHED" = "true" ]; then
-            echo "PUBLISHED=true" >> $GITHUB_OUTPUT
-          else
-            echo "PUBLISHED=false" >> $GITHUB_OUTPUT
-          fi
+          echo "published=${{ steps.changesets.outputs.published }}" >> $GITHUB_OUTPUT
 
-      # 6-2. CHANGELOG 추출
+  post-release:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      # 8. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
-        if: steps.check-published.outputs.PUBLISHED == 'true'
         id: changelog
         run: |
           VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
@@ -100,7 +101,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 7. Github 릴리즈
+      # 9. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -12,8 +12,38 @@ on:
       - dev
 
 jobs:
-  release:
+  check-labels:
     if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      has_release_label: ${{ steps.check-pr-labels.outputs.has_release_label }}
+
+    steps:
+      # 1. 레포지토리 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 2. PR 라벨 확인
+      - name: Check PR labels
+        id: check-pr-labels
+        run: |
+          # PR 라벨 목록 가져오기
+          LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
+
+          # 릴리즈 라벨 확인
+          for label in $LABELS; do
+            if [[ "$label" =~ ^release:next:(patch|minor|major)$ ]]; then
+              echo "has_release_label=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "has_release_label=false" >> $GITHUB_OUTPUT
+
+  release:
+    needs: check-labels
+    if: needs.check-labels.outputs.has_release_label == 'true'
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.check-published.outputs.published }}
@@ -90,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 8. CHANGELOG 추출
+      # 1. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
@@ -105,7 +135,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 9. Github 릴리즈
+      # 2. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -57,7 +57,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 5. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
+      # 5. changeset baseBranch를 dev 브랜치로 설정
+      - name: Set baseBranch to dev
+        run: |
+          jq '.baseBranch = "dev"' .changeset/config.json > tmp.json && mv tmp.json .changeset/config.json
+
+      # 6. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
       - name: Create release pull request or publish
         id: changesets
         uses: changesets/action@v1
@@ -67,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # 5-1. npm 레지스트리 배포 여부 확인
+      # 6-1. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
         env:
@@ -79,7 +84,7 @@ jobs:
             echo "PUBLISHED=false" >> $GITHUB_OUTPUT
           fi
 
-      # 5-2. CHANGELOG 추출
+      # 6-2. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         if: steps.check-published.outputs.PUBLISHED == 'true'
         id: changelog
@@ -95,7 +100,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 6. Github 릴리즈
+      # 7. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -70,9 +70,11 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:publish:next
+          version: prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CHANGESETS_PREID: next
 
       # 7. npm 레지스트리 배포 여부 확인
       - name: Check if published

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@seo-ny"
 
       # 3-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -57,7 +57,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 5. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
+      # 5. changeset baseBranch를 main 브랜치로 설정
+      - name: Set baseBranch to main
+        run: |
+          jq '.baseBranch = "main"' .changeset/config.json > tmp.json && mv tmp.json .changeset/config.json
+
+      # 6. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
       - name: Create release pull request or publish
         id: changesets
         uses: changesets/action@v1
@@ -67,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # 5-1. npm 레지스트리 배포 여부 확인
+      # 6-1. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
         env:
@@ -79,7 +84,7 @@ jobs:
             echo "PUBLISHED=false" >> $GITHUB_OUTPUT
           fi
 
-      # 5-2. CHANGELOG 추출
+      # 6-2. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         if: steps.check-published.outputs.PUBLISHED == 'true'
         id: changelog
@@ -95,7 +100,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 6. Github 릴리즈
+      # 7. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
@@ -117,15 +122,15 @@ jobs:
               prerelease: true
             });
 
-      # 7. jsdocs 빌드
+      # 8. jsdocs 빌드
       - name: Build jsdocs
         run: pnpm floaty:docs:build
 
-      # 8. storybook 빌드
+      # 9. storybook 빌드
       - name: Build storybook
         run: pnpm vanilla:sb:build
 
-      # 9. github pages에 jsdocs, storybook 배포
+      # 10. github pages에 jsdocs, storybook 배포
       - name: Deploy Storybook to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -15,6 +15,8 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.check-published.outputs.published }}
 
     steps:
       # 1. 레포지토리 체크아웃
@@ -72,21 +74,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # 6-1. npm 레지스트리 배포 여부 확인
+      # 7. npm 레지스트리 배포 여부 확인
       - name: Check if published
         id: check-published
-        env:
-          PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
-          if [ "$PUBLISHED" = "true" ]; then
-            echo "PUBLISHED=true" >> $GITHUB_OUTPUT
-          else
-            echo "PUBLISHED=false" >> $GITHUB_OUTPUT
-          fi
+          echo "published=${{ steps.changesets.outputs.published }}" >> $GITHUB_OUTPUT
 
-      # 6-2. CHANGELOG 추출
+  post-release:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      # 8. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
-        if: steps.check-published.outputs.PUBLISHED == 'true'
         id: changelog
         run: |
           VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
@@ -100,7 +101,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 7. Github 릴리즈
+      # 9. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
@@ -122,15 +123,15 @@ jobs:
               prerelease: true
             });
 
-      # 8. jsdocs 빌드
+      # 10. jsdocs 빌드
       - name: Build jsdocs
         run: pnpm floaty:docs:build
 
-      # 9. storybook 빌드
+      # 11. storybook 빌드
       - name: Build storybook
         run: pnpm vanilla:sb:build
 
-      # 10. github pages에 jsdocs, storybook 배포
+      # 12. github pages에 jsdocs, storybook 배포
       - name: Deploy Storybook to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@seo-ny"
 
       # 3-1. pnpm 캐시 경로 출력
       - name: Get pnpm store directory

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@ build/
 .env
 .env.*
 
-# npm token
-.npmrc
-
 # Logs
 *.log
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@seo-ny:registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
# 워크플로우 파일들 수정 (github actions 에러 대비)

## 📜 히스토리

- #7 을 머지하였으나 CI/CD가 실패하여 릴리즈 실패함
- github actions 에러는 npm 토큰 인증에 실패하였기 때문

<br />

## 📚 개요

npm 토큰 인증에 실패하여 github actions에서 에러가 발생했습니다. 이를 해결하고, 그 밖에 예상되는 문제들에 대비하여 워크플로우 파일을 수정하였습니다.

<br />

## ✅ 고민했던 부분

### 기존 문제

- changeset 워크플로를 적용하면서, 모든 변경사항 PR이 머지될 때마다 자동으로 프리릴리즈 PR이 생성되고 있음

- 이렇게 하면 모든 커밋이 프리릴리즈 버전으로 npm에 배포되지만, 이는 다음과 같은 문제를 유발함

  - 버전이 지나치게 자주 올라감 -> 버전 히스토리가 깔끔하지 않게 됨
  - 프리릴리즈 버전이 많아져 관리가 번거로움
  - 실제 테스트 목적이 아닌 단순한 코드 변경도 매번 프리릴리즈됨

### 해결 방법

평소에는 기능 PR 작성 시 프리릴리즈하지 않도록 하고, 원할 때만 프리릴리즈 하도록 함

- **프리릴리즈의 경우,**

  - 기존에는 릴리즈 할 PR vs 릴리즈 PR 만 구분하고 있었음
  - `no-release` 라벨을 추가하여 릴리즈 할 PR vs 릴리즈 안할 PR vs 릴리즈 PR 을 구분하도록 함
  - 바로 프리릴리즈 하지 않을 기능 PR 작성 시에는 `no-release` 라벨을 추가함
  - 바로 프리릴리즈할 기능 PR 작성 시에는 `release:next:(patch|minor|major)`중 하나를 선택하여 추가함

- **정식 릴리즈의 경우,**

  - main 브랜치를 대상으로 하고, main 브랜치에 상대적으로 드물게 업데이트 되며, 보통 dev 브랜치의 많은 변경사항을 한번에 머지하게 되므로 `no-release` 라벨이 필요없다고 판단하였기에 추가하지 않음

💡 **개발자가 원할 때만 프리릴리즈 하는 방법**

- 새로운 브랜치에서 `pnpm changesets` 실행하여 `.changeset/*.md` 파일을 추가함
- 해당 브랜치를 dev에 머지하는 PR을 `release:next:(patch|minor|major)` 라벨과 함께 올림
  - 이떄 본문 내용은 릴리즈 하고자 하는 모든 작업 내용을 포함해야 함
- 해당 PR을 머지하면 프리릴리즈 PR이 생성됨
- 프리릴리즈 PR을 머지하면 프리릴리즈 완료

<br />

## 📌 변경 사항

### 1) release 워크플로우 파일에 changeset baseBranch 설정 추가

- changeset baseBranch란릴리즈 PR을 만들 때 기준이 되는 브랜치를 말함
- `.changeset/config.json`에 설정해준 기본값인 baseBranch: "main" 삭제
- 각 release 워크플로우 파일에서 실제 npm 배포 하기 전에 changeset baseBranch 설정

### 2) `changesets`가 npm publish 할 때 vanilla 패키지를 ignore 하도록 설정

- floaty-core만 npm publish 되어야 하고, vanilla playground는 npm publish 되어서는 안됨
- ignore에 vanilla를 추가하더라도 vanilla 버전 관리는 정상 동작함

### 3) `npm publish` 됐을 때만 실행될 step들을 `post-release job`으로 이동시킴

- npm publish 이후의 모든 step에 if 를 추가하는 것은 너무 복잡함
- 기존의 `release job` 외에 `post-release job`을 추가함

### 4) `release-next.yml`에서 npm 배포 시 프리릴리즈 버전 설정 추가

- 프리릴리즈 시 기존에는 npm 태그에만 next를 붙이도록 되어 있었음
- 프리릴리즈 버전에도 next를 붙이고, `CHANGELOG.md`에 표시되는 프리릴리즈 버전에도 next가 추가되도록 수정

### 5) .npmrc 파일 추가, setup node.js 과정에서 `with.registry-url`, `with.scope` 추가

- github actions 실행 시 발생하는 npm 인증 에러 해결 목적
- `.npmrc` 파일보다 워크플로우에서의 `actions/setup-node@v4` 실행이 우선함

### 6) 릴리즈 PR / 릴리즈 할 PR / 릴리즈 하지 않을 PR 분기 처리 추가

- 기존에는 `release-next.yml`에서 모든 기능 PR을 dev에 머지할 때마다 릴리즈 PR을 생성했음
- 기능 PR이더라도 `no-release` 라벨을 추가한 경우, 다음 step들을 진행하지 않도록 수정
- `ci-next.yml`에도 `no-release` 라벨 관련 코드 추가
  - 유효한 라벨 목록에 `no-release` 라벨 추가
  - 기존에는 릴리즈 PR이 아니면  라벨 비교 -> 이제는 릴리즈 PR이 아니면서 `no-release`도 아닐 때만 라벨 비교

<br />

## ✨ 본 PR을 생성, 머지한 후의 예상 플로우

- 본 PR이 생성된 후 현재 브랜치에 `.changeset/*.md` 파일이 존재하지 않으므로 CI 통과 못함

  ```yml
  # ci-next.yml
  
  # 4. changeset 파일과 PR 라벨의 bump type 비교
  - name: Check changeset files
    if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' && steps.check-pr-labels.outputs.RELEASE_LABEL != 'no-release' }}
    run: |
      # changeset 파일 확인
      if ! ls .changeset/*.md 1> /dev/null 2>&1; then
        echo "::error::No changeset files found in .changeset directory"
        exit 1
      fi
  
      # changeset의 bump type 추출 -> `.changeset/*.md` 파일이 없으므로 이 값이 빈 값이 됨
      BUMP_TYPE=$(cat .changeset/*.md | grep -o '": [a-z]*' | sed 's/": //')
  
      # 라벨에서 bump type 추출
      LABEL_BUMP_TYPE=$(echo "$RELEASE_LABEL" | cut -d':' -f3)
  
      # 비교
      if [ "$BUMP_TYPE" != "$LABEL_BUMP_TYPE" ]; then
        echo "::error::Changeset bump type ($BUMP_TYPE) does not match the PR label type ($LABEL_BUMP_TYPE)"
        exit 1
      fi
  ```

- 본 PR이 머지되어도 프리릴리즈 PR이 생성되어서는 안됨

  ```yml
  # release-next.yml

  check-labels:
    if: github.event.pull_request.merged == true
    runs-on: ubuntu-latest
    outputs:
      has_release_label: ${{ steps.check-pr-labels.outputs.has_release_label }}
  
    steps:
      # 1. 레포지토리 체크아웃
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
  
      # 2. PR 라벨 확인
      - name: Check PR labels
        id: check-pr-labels
        run: |
          # PR 라벨 목록 가져오기
          LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
  
          # 릴리즈 라벨 확인
          for label in $LABELS; do
            if [[ "$label" =~ ^release:next:(patch|minor|major)$ ]]; then
              echo "has_release_label=true" >> $GITHUB_OUTPUT
              exit 0
            fi
          done
          echo "has_release_label=false" >> $GITHUB_OUTPUT
  
  release:
    needs: check-labels
    # 이 값이 'false' 이면 release job은 실행되지 않음
    if: needs.check-labels.outputs.has_release_label == 'true'
    runs-on: ubuntu-latest
    outputs:
      published: ${{ steps.check-published.outputs.published }}
  
    steps:
      - name: ...
  ```