### PR TITLE
프리릴리즈 재시도 준비 (.changeset/*.md, CHANGELOG.md)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,6 @@
   "linked": [],
   "access": "public",
   "updateInternalDependencies": "patch",
-  "ignore": ["vanilla"]
+  "ignore": ["vanilla"],
+  "baseBranch": "dev"
 }

--- a/.changeset/six-aliens-repair.md
+++ b/.changeset/six-aliens-repair.md
@@ -1,0 +1,5 @@
+---
+"@seo-ny/floaty-core": patch
+---
+
+patch version update

--- a/packages/floaty-core/CHANGELOG.md
+++ b/packages/floaty-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.0
 
+❌ 릴리즈 실패 (CI/CD 실패)
+
 ### Minor Changes
 
 - [#1](https://github.com/seo-ny/floaty/pull/1) [`76f9bc1`](https://github.com/seo-ny/floaty/commit/76f9bc100cf66c26597a6290203caa45f0d57b0a) Thanks [@seo-ny](https://github.com/seo-ny)! - minor version update

--- a/playground/vanilla/CHANGELOG.md
+++ b/playground/vanilla/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vanilla
 
+vanilla는 floaty-core를 위한 storybook playground로써 실제로 npm 배포되지 않습니다. 해당 문서는 단순 버전 관리를 위한 문서임을 밝힙니다.
+
 ## 0.1.0
 
 ### Patch Changes


### PR DESCRIPTION
# 프리릴리즈 재시도 준비 (.changeset/*.md, CHANGELOG.md)

## 📜 히스토리

- #1 
- #4 
- #5 
- #6 
- #7 

<br />

## 📚 개요

#7 에서 프리릴리즈에 실패하였는데, 이를 다시 시도하기 위해 `changesets`와 관련한 작업을 진행하였습니다.

<br />

## 📌 변경 사항

- `CHANGELOG.md` 파일에 v0.1.0 릴리즈 실패 명시
- changeset.config.json 파일에 baseBranch: dev 설정 추가
- `pnpm changeset`을 실행하여 `.changeset/*.md` 파일 생성

<br />

## ✨ 본 PR을 생성, 머지한 후의 예상 플로우

- 본 PR 생성 (w. `release:next:patch` 라벨, `.changeset/*.md` 파일) -> CI 통과
- 본 PR 머지 -> 프리릴리즈 PR 생성
- 프리릴리즈 PR 생성 -> CI 통과
- 프리릴리즈 PR 머지 -> 프리릴리즈 완료