### PR TITLE
.npmrc 파일 삭제, vanilla에 private: true 추가 (github actions 에러 대응)

### DIFF
--- a/.changeset/wet-apples-roll.md
+++ b/.changeset/wet-apples-roll.md
@@ -1,0 +1,5 @@
+---
+"@seo-ny/floaty-core": patch
+---
+
+patch version update

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 .env
 .env.*
 
+# npm token
+.npmrc
+
 # Logs
 *.log
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@seo-ny:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/floaty-core/CHANGELOG.md
+++ b/packages/floaty-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.1
 
+❌ 릴리즈 실패 (CI/CD 실패)
+
 ### Patch Changes
 
 - [#9](https://github.com/seo-ny/floaty/pull/9) [`d391065`](https://github.com/seo-ny/floaty/commit/d3910656bb6762ea583f07f70b70ecda6ea440e8) Thanks [@seo-ny](https://github.com/seo-ny)! - patch version update

--- a/packages/floaty-core/package.json
+++ b/packages/floaty-core/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/seo-ny/floaty.git",
+    "url": "git+https://github.com/seo-ny/floaty.git",
     "directory": "packages/floaty-core"
   },
   "bugs": {

--- a/playground/vanilla/package.json
+++ b/playground/vanilla/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vanilla",
+  "private": true,
   "version": "0.1.0",
   "main": "main.js",
   "type": "module",


### PR DESCRIPTION
# 🚀 .npmrc 파일 삭제, vanilla에 private: true 추가 (github actions 에러 대응)

## 📜 히스토리 및 개요

본 PR은 #11 에서 릴리즈 실패하여 원인 분석 후 수정한 PR입니다.

<br />

## 📌 변경 사항

- github actions 실행 중 npm 토큰 인증 시 층돌을 방지하기 위해 **.npmrc 파일 제거** 및 .gitignore에 추가
- vanilla playground를 npm에 배포하지 않도록 **private: true** 추가
- 프리릴리즈 재시도 준비 (`.changeset/*.md` 생성, `CHNAGELOG.md` 수정