### PR TITLE
정식 릴리즈 아닌 프리릴리즈 위한 코드 추가

### DIFF
--- a/.changeset/upset-suns-deny.md
+++ b/.changeset/upset-suns-deny.md
@@ -1,0 +1,5 @@
+---
+"@seo-ny/floaty-core": patch
+---
+
+patch version update

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+\.[0-9]+)?/ {exit}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+/ {exit}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "pnpm --filter @seo-ny/floaty-core test:coverage",
     "changeset": "changeset",
     "ci:version": "pnpm changeset version",
-    "ci:version:next": "pnpm ci:version --pre next",
+    "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version --pre next",
     "ci:publish": "pnpm changeset publish",
     "ci:publish:next": "pnpm ci:publish --tag next",
     "prepare": "husky"


### PR DESCRIPTION
# 🚀 정식 릴리즈 아닌 프리릴리즈 위한 코드 추가

## 📚 개요

#13 에서 0.1.2 버전을 npm 레지스트리에 배포하였으나 의도와는 달리 프리릴리즈 버전이 아니라 정식 릴리즈 버전으로 배포되었습니다. 또한, `release-next.yml`에서 `post-release job`을 끝까지 실행하지 못하고 github actions가 에러를 감지하여 종료되었습니다. 본 PR은 이 문제들을 수정한 작업을 포함합니다. 본 PR 머지후 생성된 프리릴리즈 PR이 머지되면서 정상적으로 프리릴리즈가 완료되는지, `post-release job`이 수행되는지 확인이 필요합니다.

## 📌 변경 사항

- 프리릴리즈 버전 업데이트 시 **프리릴리즈 모드 진입 코드** 추가
  ```bash
  "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version --pre next"
  ```
- `release-next.yml`과 `release-prod.yml`에서 `post-release job`의 틀린 경로 바르게 수정