### PR TITLE
프리릴리즈 버전으로 배포 전에 프리릴리즈 모드 종료

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ci:version": "pnpm changeset version",
     "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version --pre next",
     "ci:publish": "pnpm changeset publish",
-    "ci:publish:next": "pnpm ci:publish --tag next",
+    "ci:publish:next": "pnpm changeset pre exit && pnpm ci:publish --tag next",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
# 프리릴리즈 버전으로 배포 전에 프리릴리즈 모드 종료

본 PR은 github actions 실행 시 발생한 다음 에러를 해결하기 위한 PR입니다.

> 🦋  error Releasing under custom tag is not allowed in pre mode
🦋  To resolve this exit the pre mode by running `changeset pre exit`

다음과 같이 수정하였습니다.

```bash
# pacakge.json

"ci:publish:next": "pnpm changeset pre exit && pnpm ci:publish --tag next"
```