### PR TITLE
changesets/action@v1.4.5 제거하고 대신 changeset cli 사용

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -119,11 +119,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. CHANGELOG 추출
+      # 1. 레포지토리 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 2. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('${{ github.workspace }}/packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+\.[0-9]+)?/ {exit}
@@ -134,7 +140,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 2. Github 릴리즈
+      # 3. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -46,7 +46,7 @@ jobs:
     if: needs.check-labels.outputs.has_release_label == 'true'
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.check-published.outputs.published }}
+      published: ${{ steps.set-published.outputs.published }}
 
     steps:
       # 1. 레포지토리 체크아웃
@@ -91,27 +91,51 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 5. changeset baseBranch를 dev 브랜치로 설정
-      - name: Set baseBranch to dev
+      # 5. 프리릴리즈 모드 진입
+      - name: Ensure pre.json exists
         run: |
-          jq '.baseBranch = "dev"' .changeset/config.json > tmp.json && mv tmp.json .changeset/config.json
+          if [ ! -f .changeset/pre.json ]; then
+            pnpm ci:pre:enter
+          fi
 
-      # 6. 버전 업데이트 PR 생성 또는 npm 레지스트리 배포
-      - name: Create release pull request or publish
-        id: changesets
-        uses: changesets/action@v1.4.5
-        with:
-          version: pnpm ci:version:next
-          publish: pnpm ci:publish:next
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # 7. npm 레지스트리 배포 여부 확인
-      - name: Check if published
-        id: check-published
+      # 6. .changeset/.md 파일 존재 여부 확인
+      - name: Check if changesets exist
+        id: check_changesets
         run: |
-          echo "published=${{ steps.changesets.outputs.published }}" >> $GITHUB_OUTPUT
+          if ls .changeset/*.md 1> /dev/null 2>&1; then
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
+      # 7. .changeset/.md 파일이 존재하면, 프리릴리즈 버전 PR 생성
+      - name: Create prerelease version PR
+        if: steps.check_changesets.outputs.found == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          pnpm ci:version:next
+          git add .
+          git commit -m "chore: prerelease 버전 업데이트"
+          git push origin HEAD:prerelease/next-${{ github.sha }}
+
+      # 8. .changeset/.md 파일이 존재하지 않으면, npm 레지스트리 배포 (프리릴리즈)
+      - name: Publish if no .changeset/*.md
+        if: steps.check_changesets.outputs.found == 'false'
+        run: |
+          OUTPUT=$(pnpm ci:publish:next)
+          echo "$OUTPUT" | tee publish-output.txt
+
+      # 9. npm 레지스트리 배포 여부 확인
+      - name: Set output if published
+        id: set-published
+        if: steps.check_changesets.outputs.found == 'false'
+        run: |
+          if grep -q "Successfully published:" publish-output.txt; then
+            echo "published=true" >> $GITHUB_OUTPUT
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+          fi
 
   post-release:
     needs: release
@@ -125,7 +149,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 2. CHANGELOG 추출
+      # 2. Node.js 설정
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # 3. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
@@ -140,7 +170,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 3. Github 릴리즈
+      # 4. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:
@@ -159,5 +189,5 @@ jobs:
               tag_name: tag,
               name,
               body,
-              prerelease: false
+              prerelease: true
             });

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('${{ github.workspace }}/packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+\.[0-9]+)?/ {exit}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -88,11 +88,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 8. CHANGELOG 추출
+      # 1. 레포지토리 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 2. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+/ {exit}
@@ -103,7 +109,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 9. Github 릴리즈
+      # 3. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -88,17 +88,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. 레포지토리 체크아웃
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # 2. CHANGELOG 추출
+      # 8. CHANGELOG 추출
       - name: Read CHANGELOG for Release Notes
         id: changelog
         run: |
-          VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
+          VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+/ {exit}
@@ -109,7 +103,7 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
-      # 3. Github 릴리즈
+      # 9. Github 릴리즈
       - name: Create GitHub Release
         uses: actions/github-script@v7
         env:

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "test": "pnpm --filter @seo-ny/floaty-core test",
     "test:coverage": "pnpm --filter @seo-ny/floaty-core test:coverage",
     "changeset": "changeset",
-    "ci:version": "pnpm changeset version",
-    "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version --pre next",
+    "ci:version": "pnpm changeset pre exit && pnpm changeset version",
+    "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version",
     "ci:publish": "pnpm changeset publish",
-    "ci:publish:next": "pnpm changeset pre exit && pnpm ci:publish --tag next",
+    "ci:publish:next": "pnpm ci:publish",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "test": "pnpm --filter @seo-ny/floaty-core test",
     "test:coverage": "pnpm --filter @seo-ny/floaty-core test:coverage",
     "changeset": "changeset",
-    "ci:version": "pnpm changeset pre exit && pnpm changeset version",
-    "ci:version:next": "pnpm changeset pre enter next && pnpm ci:version",
-    "ci:publish": "pnpm changeset publish",
-    "ci:publish:next": "pnpm ci:publish",
+    "ci:pre:enter": "pnpm changeset pre enter next",
+    "ci:pre:exit": "pnpm changeset pre exit",
+    "ci:version:next": "pnpm changeset version",
+    "ci:version": "ci:pre:exit && pnpm changeset version",
+    "ci:publish:next": "pnpm changeset publish",
+    "ci:publish": "ci:pre:exit && pnpm changeset publish",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
# `changesets/action@v1.4.5` 제거하고 대신 changeset cli 사용

## 📜 히스토리

- #17 

<br />

## 📚 개요

본 PR은 #17 에서 발생한 다음 2가지 문제를 해결한 작업을 포함하고 있습니다. #17 에서 프리릴리즈 PR 생성 과정 없이 바로 프리릴리즈가 되었습니다. 프리릴리즈는 의도치 않게 성공했으나 이후 github 릴리즈 노트 생성 과정에서 에러가 발생했습니다. 

<br />

## 💡 문제

### 1) 프리릴리즈 과정 설계

다음과 같은 순서를 따르고자 합니다. 기능 PR 머지 시 바로 프리릴리즈 되지 않고 프리릴리즈 PR 생성 후 이를 머지했을 떄 npm 배포가 되어야 합니다. 이는 다음에 배포될 버전을 작접 확인한 후 배포하기 위함입니다. 개발자가 의도한 다음 버전과 changeset이 바꾼 버전이 일치하는지 확인한 후 개발자가 머지 버튼을 눌러 최종적으로 릴리즈를 트리거합니다. 정식 릴리즈의 경우에도 동일한 과정을 거칩니다.

- 기능 PR 작성
- 기능 PR 머지
- 프리릴리즈 PR 생성
- 프리릴리즈 PR 머지
- 프리릴리즈

### 2) `changesets/action@v1.4.5`의 작동 원리

`changesets/action@v1.4.5`는 내부적으로 다음과 같은 기준으로 상황에 따라 자체적으로 판단한 후 동작합니다.

- 현재 브랜치와 기준 브랜치를 비교하여 그 결과에 따라 달리 행동함
    - 현재 브랜치: github actions가 실행되는 브랜치 (머지 직후의 상태)
    - 기준 브랜치: github 레포 세팅에 설정해둔 default branch (`floaty` 레포의 경우, main 브랜치가 됨)

**[ 정식 릴리즈 ]**

- 현재 브랜치 main 브랜치 === 기준 브랜치 main 브랜치
    - `.changeset/*.md` 파일 유무와 상관없이 무조건 바로 npm publish 함
    - 즉, 정식 릴리즈 과정에서 1.4.5를 사용하면 위의 설계대로 프리릴리즈 과정을 구현할 수 없음

**[ 프리릴리즈 ]**

- 현재 브랜치 dev 브랜치 !== 기준 브랜치 main 브랜치
    - `.changeset/*.md` 파일 유무에 따라 동작이 달라짐
        - `.changeset/*.md` 파일이 있으면 프리릴리즈 PR 생성
        - `.changeset/*.md` 파일이 없으면 바로 npm publish 함

- 단, `pre.json` 파일이 있으면, `.changeset/*.md` 파일이 있더라도 프리릴리즈 모드라고 간주하고 바로 npm publish 함
    - `pre.json` 파일은 프리릴리즈 모드로 진입 시(`ci:version:next` 실행 시) 생성됨
    - 예외적으로 `ci:version:next` 를 실행하면 `pre.json` 파일이 만들어지고 그 후 버전 업데이트를 진행함으로 `x.x.x-next.0`의 경우에만 프리릴리즈 PR을 생성함

### 3) 너무 복잡한 예외 처리

- 코드를 깔끔하게 작성하고 실수없이 실행하기 위해 `changesets/action@v1.4.5`를 도입하였으나, 이를 사용하여 의도한 설계대로 구현하기 위해서는 예외 처리할 부분이 너무 많아짐
- 뿐만 아니라 github actions 에러 로그에서도 세부적으로 어떤 과정에서 에러가 난 것인지 명확히 확인이 어려움
- 결국 `changesets/action@v1.4.5`를 제거하고 워크플로우 파일에서 changeset cli를 사용하기로 함

<br />

## 📌 변경 사항

### 1) `release-next.yml` 파일에서 changesets/action@v1.4.5` 제거하고 대신 changeset cli 사용

`release-prod.yml`은 아직 수정 전입니다. 우선 빈번이 파일이 수정되어 혼란을 가중시켜 프리릴리즈 과정을 먼저 테스트한 후 수정하고자 합니다. 자세한 변경사항은 `files changed` 탭을 참고해주세요.

**⚠️ 주의 ⚠️**

```yaml
# 5. 프리릴리즈 모드 진입
- name: Ensure pre.json exists
  run: |
    if [ ! -f .changeset/pre.json ]; then
      pnpm ci:pre:enter
    fi
```

프리릴리즈 모드 진입 명령어는 현재 브랜치(머지 후의 dev 브랜치)에 pre.json 파일이 없는 경우에만 실행되어야 합니다. 변경 전에는 version을 올릴 때마다 프리릴리즈 모드로 진입하면 PR을 머지할 때마다 프리릴리즈 버전이 올라가도록 되어 있었습니다. 이를 위와 같이 수정하였습니다.

### 2) package.json의 scripts 수정

```json
"ci:pre:enter": "pnpm changeset pre enter next",
"ci:pre:exit": "pnpm changeset pre exit",
"ci:version:next": "pnpm changeset version",
"ci:version": "ci:pre:exit && pnpm changeset version",
"ci:publish:next": "pnpm changeset publish",
"ci:publish": "ci:pre:exit && pnpm changeset publish"
```

### 3) post-prerelease job에서 상대 경로 에러 수정

github actions의 run 블록은 기본적으로 checkout된 코드의 루트에서 실행되므로 상대 경로 또한 현재 파일의 위치가 아니라 루트를 기준으로 작성해야 합니다.

```yaml
VERSION=$(node -p "require('../../packages/floaty-core/package.json').version")         # 기존 코드
VERSION=$(node -p "require('./packages/floaty-core/package.json').version")             # 수정한 코드
```