### PR TITLE
github actions PR 라벨 확인 에러 해결

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -30,7 +30,7 @@ jobs:
         id: check-pr-labels
         run: |
           # PR 라벨 목록 가져오기
-          LABELS=$(echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | jq -r '.[]')
+          LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
 
           # 릴리즈 라벨 확인
           for label in $LABELS; do


### PR DESCRIPTION
# github actions PR 라벨 확인 에러 해결

- `echo "${{ toJSON(...) }}"` -> `echo '${{ toJSON(...) }}'` 로 변경
- bash는 큰따옴표가 있으면 줄바꿈이 있거나 이스케이프 문자가 있을 겨우  여러 줄 문자열로 처리해서 파싱 에러가 남
- 이를 해결하기 위해 큰따옴표에서 작은따옴표로 변경함