### PR TITLE
release-next.yml에 디버깅 코드 추가

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -119,12 +119,28 @@ jobs:
             pnpm ci:pre:enter
           fi
 
+      # 7-1. 디버깅 정보 출력
+      - name: Debug environment
+        if: steps.check_changesets.outputs.found == 'true'
+        run: |
+          echo "Current version: $(node -p "require('./packages/floaty-core/package.json').version")"
+          echo "Changeset files:"
+          ls -la .changeset/
+          echo "pre.json content:"
+          cat .changeset/pre.json
+          echo "Changeset content:"
+          cat .changeset/*.md
+
       # 8. (〃) 버전 업데이트
       - name: Run changeset version
         if: steps.check_changesets.outputs.found == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-        run: pnpm ci:version:next
+        run: |
+          pnpm ci:version:next
+          echo "Version after changeset: $(node -p "require('./packages/floaty-core/package.json').version")"
+          git status
+          git diff
 
       # 8-1. (〃) 버전 출력
       - name: Get updated version from package.json


### PR DESCRIPTION
# `release-next.yml`에 디버깅 코드 추가

github actions에서 버전 업데이트를 했음에도 변경사항 없이 새로운 브랜치가 만들어지고 PR이 생성되지 않는 문제가 있습니다.

changeset version 실행 전후 .changeset 폴더를 확인하기 위해 디버깅 코드를 추가했습니다.