### PR TITLE
버전 업데이트 이전으로 되돌림, 워크플로우에서 PR 라벨 관련 불필요한 코드 제거

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,7 +5,5 @@
     "@seo-ny/floaty-core": "0.1.3-next.0",
     "vanilla": "0.1.0"
   },
-  "changesets": [
-    "tangy-gifts-shave"
-  ]
+  "changesets": []
 }

--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -46,7 +46,7 @@ jobs:
           LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
 
           # 유효한 라벨 목록
-          VALID_LABELS=("release:next:patch" "release:next:minor" "release:next:major" "no-release")
+          VALID_LABELS=("release:next:patch" "release:next:minor" "release:next:major")
 
           # 유효한 라벨 필터링
           MATCHED_LABELS=()
@@ -70,7 +70,7 @@ jobs:
 
       # 4. changeset 파일과 PR 라벨의 bump type 비교
       - name: Check changeset files
-        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' && steps.check-pr-labels.outputs.RELEASE_LABEL != 'no-release' }}
+        if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
           # changeset 파일 확인
           if ! ls .changeset/*.md 1> /dev/null 2>&1; then

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -12,38 +12,8 @@ on:
       - dev
 
 jobs:
-  check-labels:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    outputs:
-      has_release_label: ${{ steps.check-pr-labels.outputs.has_release_label }}
-
-    steps:
-      # 1. 레포지토리 체크아웃
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # 2. PR 라벨 확인
-      - name: Check PR labels
-        id: check-pr-labels
-        run: |
-          # PR 라벨 목록 가져오기
-          LABELS=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
-
-          # 릴리즈 라벨 확인
-          for label in $LABELS; do
-            if [[ "$label" =~ ^release:next:(patch|minor|major)$ ]]; then
-              echo "has_release_label=true" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-          done
-          echo "has_release_label=false" >> $GITHUB_OUTPUT
-
   release:
-    needs: check-labels
-    if: needs.check-labels.outputs.has_release_label == 'true'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.set-published.outputs.published }}

--- a/packages/floaty-core/CHANGELOG.md
+++ b/packages/floaty-core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @seo-ny/floaty-core
 
-## 0.1.3-next.1
-
-### Patch Changes
-
-- [#28](https://github.com/seo-ny/floaty/pull/28) [`66de0bf`](https://github.com/seo-ny/floaty/commit/66de0bfb58f4fa93f2ac0923bcba5e002758618b) Thanks [@seo-ny](https://github.com/seo-ny)! - patch version update
-
 ## 0.1.3-next.0
 
 ### Patch Changes

--- a/packages/floaty-core/package.json
+++ b/packages/floaty-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo-ny/floaty-core",
-  "version": "0.1.3-next.1",
+  "version": "0.1.3-next.0",
   "description": "Floating logic core for positioning elements (vanilla JS)",
   "main": "./dist/floaty.umd.js",
   "module": "./dist/floaty.mjs",


### PR DESCRIPTION
# 🚀 버전 업데이트 이전으로 되돌림, 워크플로우에서 PR 라벨 관련 불필요한 코드 제거

## 📜 히스토리

- #31 에서 원격에서 변경사항을 감지하고 버전 업데이트 PR(프리릴리즈 PR)을 생성하도록 수정했습니다.
  - `peter-evans/create-pull-request@v5` 실행 시 내부적으로 변경사항을 감지하지 못하고 있었습니다.
  - github cli를 이용하여 PR을 생성하도록 수정하니 정상적으로 변경사항이 감지되었습니다.
- #32 에서 CI를 통과하지 못해 몇 가지를 수정하여 통과시킨 후에 머지를 진행하였는데, 워크플로우가 예상치 못하게 일찍 종료되었습니다.

<br />

## 📚 개요

#32 에서 `release-next.yml`을 실행하면서 check-labels job에서 `has_release_label == 'false'` 라서 다음 job들이 모두 실행되지 않았습니다. 에러는 나지 않았지만 npm에 배포되지는 않은 채로 버전만 업데이트 되어 dev 브랜치에 머지되었습니다. 이를 원복하면서 동시에 워크플로우 파일에서 라벨 관련 불필요한 코드를 제거하였습니다.

<br />

## 📌 변경 사항

### 1) 0.1.3-next.1로 버전 업데이트를 이전으로 되돌림

- 0.1.3-next.1 -> 0.1.3-next.0로 변경
- CHANGELOG.md에서 0.1.3-next.1 제거
- `pre.json` 파일의 changesets에 추가된 md 파일 제거

### 2) 워크플로우 파일에서 PR 라벨 관련 불필요한 코드 제거

**[ ci-next.yml ]**

- 유효한 PR 라벨 목록에서 `no-release` 라벨 제거
  - 기능 PR에서 유효한 라벨은 `release:next:patch`, `release:next:minor`, `release:next:major` 세 개뿐임
- 버전 업데이트 PR 여부는 PR 제목으로 판별하도록 함 (PR 라벨 사용 X)

**[ release-next.yml ]**

- check-labels job 제거
- `ci-next.yml`에서 라벨 체크를 통과해야만 머지가 가능해져 `release-next.yml`가 실행되도록 함
- 중복 검사할 필요 없으므로 필요없는 코드를 제거함