### PR TITLE
npm 배포 확인 로직 수정, .changeset/*.md 파일 하나 더 추가, CI 에러 수정

### DIFF
--- a/.changeset/sad-showers-play.md
+++ b/.changeset/sad-showers-play.md
@@ -1,0 +1,5 @@
+---
+"@seo-ny/floaty-core": patch
+---
+
+patch version udpate

--- a/.github/workflows/ci-next.yml
+++ b/.github/workflows/ci-next.yml
@@ -61,7 +61,7 @@ jobs:
           MATCHED_COUNT=${#MATCHED_LABELS[@]}
 
           if [ "$MATCHED_COUNT" -ne 1 ]; then
-            echo "::error::Exactly one valid label must be present. Found $MATCHED_COUNT. Expected one of: ${VALID_LABELS[*]}"
+            echo "❌ Exactly one valid label must be present. Found $MATCHED_COUNT. Expected one of: ${VALID_LABELS[*]}"
             exit 1
           fi
 
@@ -72,23 +72,34 @@ jobs:
       - name: Check changeset files
         if: ${{ steps.check-release-pr.outputs.is_release_pr == 'false' }}
         run: |
-          # changeset 파일 확인
-          if ! ls .changeset/*.md 1> /dev/null 2>&1; then
-            echo "::error::No changeset files found in .changeset directory"
+          # PR에 새로 추가된 changeset 파일 확인
+          NEW_CHANGESET_FILES=$(git diff --name-only origin/dev...HEAD .changeset/ | grep '\.md$')
+
+          if [ -z "$NEW_CHANGESET_FILES" ]; then
+            echo "❌ No new changeset files found in this PR"
             exit 1
           fi
 
-          # changeset의 bump type 추출
-          BUMP_TYPE=$(cat .changeset/*.md | grep -o '": [a-z]*' | sed 's/": //')
+          # PR에 changeset 파일이 하나만 추가되었는지 확인
+          CHANGESET_COUNT=$(echo "$NEW_CHANGESET_FILES" | wc -l)
+          if [ "$CHANGESET_COUNT" -gt 1 ]; then
+            echo "❌ Multiple changeset files added in this PR. Please include only one changeset file per PR."
+            echo "Found files:"
+            echo "$NEW_CHANGESET_FILES"
+            exit 1
+          fi
 
           # 라벨에서 bump type 추출
           LABEL_BUMP_TYPE=$(echo "$RELEASE_LABEL" | cut -d':' -f3)
 
-          # 비교
+          # 새로 추가된 changeset 파일의 bump type 확인
+          BUMP_TYPE=$(grep -o '": [a-z]*' "$NEW_CHANGESET_FILES" | sed 's/": //')
           if [ "$BUMP_TYPE" != "$LABEL_BUMP_TYPE" ]; then
-            echo "::error::Changeset bump type ($BUMP_TYPE) does not match the PR label type ($LABEL_BUMP_TYPE)"
+            echo "❌ Changeset file has bump type ($BUMP_TYPE) which does not match the PR label type ($LABEL_BUMP_TYPE)"
             exit 1
           fi
+
+          echo "✅ Changeset file has matching bump type ($LABEL_BUMP_TYPE)"
 
       # 5. pnpm 설치
       - name: Install pnpm

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.set-published.outputs.published }}
+      published: ${{ steps.publish.outputs.published }}
 
     steps:
       # 1. 레포지토리 체크아웃
@@ -193,23 +193,19 @@ jobs:
           echo "=== After PR creation ==="
           gh pr list --head ${{ steps.branch.outputs.branch }} --json number,title,state
 
-      # 11. (현재 PR이 릴리즈 PR이면) npm 레지스트리 배포
+      # 11. (현재 PR이 릴리즈 PR이면) npm 배포 및 배포 여부 확인
       - name: Publish if not release PR
         if: steps.check-release-pr.outputs.is_release_pr == 'true'
+        id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          OUTPUT=$(pnpm ci:publish:next)
-          echo "$OUTPUT" | tee publish-output.txt
-
-      # 12. npm 레지스트리 배포 여부 확인
-      - name: Set output if published
-        id: set-published
-        run: |
-          if [ -f publish-output.txt ] && grep -q "Successfully published:" publish-output.txt; then
+          if pnpm ci:publish:next; then
             echo "published=true" >> $GITHUB_OUTPUT
           else
             echo "published=false" >> $GITHUB_OUTPUT
+            echo "❌ Failed to publish packages"
+            exit 1
           fi
 
   post-release:


### PR DESCRIPTION
# 🚀 npm 배포 확인 로직 수정, `.changeset/*.md` 파일 하나 더 추가, CI 에러 수정

에러 로그 확인을 위해 코드를 추가하고, next.2 버전으로 업데이트하기 위해 md 파일을 하나 더 추가했습니다. CI 에러가 발생하여 코드를 수정했습니다.

<br />

## 📌 변경 사항

- `release-next.yml`에서 npm 배포 중 에러 발생 시 명확히 알 수 있도록 에러 로그 추가

- `ci-next.yml`에서 라벨 비교 시 현재 PR에서 추가한 md 파일만 고려하도록 수정

- `.changeset/*.md` 파일 하나 더 추가

    - 프리릴리즈 시에는 버전 업데이트 해도 `.changeset/*.md` 파일이 사라지지 않음

    - 프리릴리즈 버전을 업데이트 하려면 `pnpm changeset`을 실행해 md 파일을 추가해야 함

      - 새로운 md는 `changeset version` 실행 시 `pre.json`의 changesets 배열에 자동 추가됨

    - 각 md 파일은 버전별 변경사항을 추적하기 위해 각각 별도로 관리됨

<br />

## ✨ 본 PR 머지 후...

- 0.1.3-next.2 버전으로 프리릴리즈 되어야 함

- post-release job이 실행되어 CHANGELOG.md를 바탕으로 github 릴리즈 노트를 생성하여 github에 릴리즈 되어야 함