### PR TITLE
릴리즈 노트 생성 버그 수정

### DIFF
--- a/.changeset/icy-coats-study.md
+++ b/.changeset/icy-coats-study.md
@@ -1,0 +1,5 @@
+---
+"@seo-ny/floaty-core": patch
+---
+
+patch version update

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -161,6 +161,7 @@ jobs:
         id: changelog
         run: |
           VERSION=$(node -p "require('./packages/floaty-core/package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           NOTES=$(awk -v ver="## ${VERSION}" '
             $0 ~ ver {capture=1; next}
             capture && /^## [0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+\.[0-9]+)?/ {exit}
@@ -188,6 +189,7 @@ jobs:
               owner,
               repo,
               tag_name: tag,
+              target_commitish: context.sha,
               name,
               body,
               prerelease: true


### PR DESCRIPTION
# `release-next.yml`에서 "Create Github Release" 버그 수정

- `target_commitish` 속성 추가

  - 이 속성이 없어서 github 릴리즈 소스코드의 기준이 기본값인 `default branch`의 최신 커밋이 되었음

  - 그 값으로 `context.sha`(github actions가 실행되는 현재 커밋의 해시를 가리킴) 지정

- `VERSION`을 `$GITHUB_OUTPUT`으로 내보내도록 함

  - 이전 step에서 VERSION을 내보내지 않아 github 릴리즈 페이지에서 제목과 태그에서 버전이 빈 값으로 표기되었음
